### PR TITLE
test: config unit tests

### DIFF
--- a/config/config_client_test.go
+++ b/config/config_client_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 IndyKite
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"context"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/indykite/indykite-sdk-go/config"
+	configmock "github.com/indykite/indykite-sdk-go/test/config/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ConfigNode", func() {
+	var (
+		ctx          context.Context
+		mockCtrl     *gomock.Controller
+		mockClient   *configmock.MockConfigManagementAPIClient
+		configClient *config.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = configmock.NewMockConfigManagementAPIClient(mockCtrl)
+	})
+
+	Describe("Client", func() {
+		It("New", func() {
+			var err error
+			configClient, err = config.NewTestClient(ctx, mockClient)
+			Ω(err).To(Succeed())
+			Expect(configClient).To(Not(BeNil()))
+
+			if configClient != nil {
+				Expect(configClient.Close()).To(Succeed())
+			}
+		})
+
+	})
+})

--- a/config/config_node_test.go
+++ b/config/config_node_test.go
@@ -1,0 +1,1130 @@
+// Copyright (c) 2023 IndyKite
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/indykite/indykite-sdk-go/config"
+	sdkerrors "github.com/indykite/indykite-sdk-go/errors"
+	configpb "github.com/indykite/indykite-sdk-go/gen/indykite/config/v1beta1"
+	"github.com/indykite/indykite-sdk-go/test"
+	configmock "github.com/indykite/indykite-sdk-go/test/config/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("ConfigNode", func() {
+	var (
+		ctx          context.Context
+		mockCtrl     *gomock.Controller
+		mockClient   *configmock.MockConfigManagementAPIClient
+		configClient *config.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = configmock.NewMockConfigManagementAPIClient(mockCtrl)
+
+		var err error
+		configClient, err = config.NewTestClient(ctx, mockClient)
+		Ω(err).To(Succeed())
+	})
+
+	Describe("ConfigNode", func() {
+		It("Nil request", func() {
+			resp, err := configClient.ReadConfigNode(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil or not read request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("Wrong id should return a validation error in the response", func() {
+			configNodeRequest, err := config.NewRead("gid:like")
+			Ω(err).To(Succeed())
+			resp, err := configClient.ReadConfigNode(ctx, configNodeRequest)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+
+		})
+
+		It("ReadSuccessReadId", func() {
+			configNodeRequest, err := config.NewRead("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.WithBookmarks([]string{"something-like-bookmark-which-is-long-enough"})
+			beResp := &configpb.ReadConfigNodeResponse{
+				ConfigNode: &configpb.ConfigNode{
+					Id:          "gid:like-real-config-node-id",
+					Name:        "like-real-config-node-name",
+					DisplayName: "Like Real Config-Node Name",
+					CreatedBy:   "creator",
+					CreateTime:  timestamppb.Now(),
+					CustomerId:  "gid:like-real-customer-id",
+					AppSpaceId:  "gid:like-real-app-space-id",
+					TenantId:    "gid:like-real-tenant-id",
+					Etag:        "123qwe",
+					Config: &configpb.ConfigNode_ReadidProviderConfig{
+						ReadidProviderConfig: &configpb.ReadIDProviderConfig{
+							SubmitterSecret:   "submitter-secret-12345678901234567890",
+							ManagerSecret:     "manager-secret-123456789012345678901234",
+							SubmitterPassword: "submitter-password",
+							HostAddress:       "<https://saas-preprod.readid.com>",
+							PropertyMap: map[string]*configpb.ReadIDProviderConfig_Property{
+								"Propertymap": {Expression: "property", Enabled: true},
+							},
+							UniquePropertyName: "uniquepropertyname",
+						},
+					},
+				},
+			}
+			mockClient.EXPECT().
+				ReadConfigNode(
+					gomock.Any(),
+					test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Id": Equal("gid:like-real-config-node-id"),
+					}))),
+					gomock.Any(),
+				).Return(beResp, nil)
+
+			resp, err := configClient.ReadConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("ReadSuccessOAuth2Client", func() {
+			configNodeRequest, err := config.NewRead("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.WithBookmarks([]string{"something-like-bookmark-which-is-long-enough"})
+			beResp := &configpb.ReadConfigNodeResponse{
+				ConfigNode: &configpb.ConfigNode{
+					Id:          "gid:like-real-config-node-id",
+					Name:        "like-real-config-node-name",
+					DisplayName: "Like Real Config-Node Name",
+					CreatedBy:   "creator",
+					CreateTime:  timestamppb.Now(),
+					CustomerId:  "gid:like-real-customer-id",
+					AppSpaceId:  "gid:like-real-app-space-id",
+					TenantId:    "gid:like-real-tenant-id",
+					Etag:        "123qwe",
+					Config: &configpb.ConfigNode_Oauth2ClientConfig{
+						Oauth2ClientConfig: &configpb.OAuth2ClientConfig{
+							ProviderType:  configpb.ProviderType_PROVIDER_TYPE_GOOGLE_COM,
+							ClientId:      "manager-secret-123456789012345678901234",
+							ClientSecret:  "submitter-password",
+							DefaultScopes: []string{"openid", "profile", "email"},
+							AllowedScopes: []string{"openid", "profile", "email"},
+						},
+					},
+				},
+			}
+			mockClient.EXPECT().
+				ReadConfigNode(
+					gomock.Any(),
+					test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Id": Equal("gid:like-real-config-node-id"),
+					}))),
+					gomock.Any(),
+				).Return(beResp, nil)
+
+			resp, err := configClient.ReadConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("ReadError", func() {
+			configNodeRequest, err := config.NewRead("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			beResp := &configpb.ReadConfigNodeResponse{
+				ConfigNode: &configpb.ConfigNode{
+					Id:     "gid:like-real-config-node-id",
+					Name:   "like-real-config-node-name",
+					Etag:   "123qwe",
+					Config: &configpb.ConfigNode_ReadidProviderConfig{},
+				},
+			}
+			mockClient.EXPECT().
+				ReadConfigNode(
+					gomock.Any(),
+					test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Id": Equal("gid:like-real-config-node-id"),
+					}))),
+					gomock.Any(),
+				).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.ReadConfigNode(ctx, configNodeRequest)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+
+		It("ReadString", func() {
+
+			configNodeRequest, err := config.NewRead("gid:like-real-config-node-id")
+			resp := configNodeRequest.String()
+
+			Expect(resp).To(Not(BeNil()))
+			Expect(err).To(Succeed())
+			Expect(configNodeRequest).To(ContainSubstring("Read gid:like-real-config-node-id configuration"))
+		})
+
+		It("ReadWithNameString", func() {
+			configNodeRequest, err := config.NewReadWithName("like-real-config-node-name")
+			Expect(configNodeRequest).To(Not(BeNil()))
+			Expect(err).To(Succeed())
+		})
+
+		It("ReadWithNameStringError", func() {
+			configNodeRequest, err := config.NewReadWithName("1234")
+			Expect(configNodeRequest).To(BeNil())
+			Expect(err).ToNot(Succeed())
+		})
+
+		It("ReadStringNothing", func() {
+			var configNodeRequest config.NodeRequest
+			Expect(configNodeRequest.String()).To(Not(BeNil()))
+			Expect(configNodeRequest.String()).To(ContainSubstring("Invalid empty request"))
+		})
+
+	})
+
+	Describe("ConfigNodeCreate", func() {
+		It("Nil request", func() {
+			resp, err := configClient.CreateConfigNode(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil or not create request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("CreateReadId", func() {
+			configuration := &configpb.ReadIDProviderConfig{
+				SubmitterSecret:   "submitter-secret-12345678901234567890",
+				ManagerSecret:     "manager-secret-123456789012345678901234",
+				SubmitterPassword: "submitter-password",
+				HostAddress:       "<https://saas-preprod.readid.com>",
+				PropertyMap: map[string]*configpb.ReadIDProviderConfig_Property{
+					"Propertymap": {Expression: "property", Enabled: true},
+				},
+				UniquePropertyName: "uniquepropertyname",
+			}
+
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithDescription("Description ConfigNode")
+			configNodeRequest.WithBookmarks([]string{"something-like-bookmark-which-is-long-enough"})
+			configNodeRequest.WithReadidProviderConfig(configuration)
+
+			beResp := &configpb.CreateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwe",
+				CreatedBy:  "creator",
+				CreateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().CreateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Name":     Equal("like-real-config-node-name"),
+					"Location": Equal("gid:like-real-customer-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"ReadidProviderConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"SubmitterSecret": Equal("submitter-secret-12345678901234567890"),
+							"ManagerSecret":   Equal("manager-secret-123456789012345678901234"),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("CreateOAuth2Client", func() {
+			configuration := &configpb.OAuth2ClientConfig{
+				ProviderType:  configpb.ProviderType_PROVIDER_TYPE_GOOGLE_COM,
+				ClientId:      "client-id-123456789012345678901234",
+				ClientSecret:  "client-secret",
+				DefaultScopes: []string{"openid", "profile", "email"},
+				AllowedScopes: []string{"openid", "profile", "email"},
+			}
+
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithOAuth2ClientConfig(configuration)
+
+			beResp := &configpb.CreateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwe",
+				CreatedBy:  "creator",
+				CreateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().CreateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Name":     Equal("like-real-config-node-name"),
+					"Location": Equal("gid:like-real-customer-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Oauth2ClientConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"ClientId":     Equal("client-id-123456789012345678901234"),
+							"ClientSecret": Equal("client-secret"),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("CreateWebauthnProvider", func() {
+			configuration := &configpb.WebAuthnProviderConfig{
+				RelyingParties:          map[string]string{"http://localhost": "localhost"},
+				AttestationPreference:   configpb.ConveyancePreference_CONVEYANCE_PREFERENCE_NONE,
+				AuthenticatorAttachment: configpb.AuthenticatorAttachment_AUTHENTICATOR_ATTACHMENT_DEFAULT,
+				RequireResidentKey:      false,
+				UserVerification:        configpb.UserVerificationRequirement_USER_VERIFICATION_REQUIREMENT_PREFERRED,
+				RegistrationTimeout:     &durationpb.Duration{Seconds: 30},
+				AuthenticationTimeout:   &durationpb.Duration{Seconds: 60},
+			}
+
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithWebauthnProviderConfig(configuration)
+
+			beResp := &configpb.CreateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwe",
+				CreatedBy:  "creator",
+				CreateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().CreateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Name":     Equal("like-real-config-node-name"),
+					"Location": Equal("gid:like-real-customer-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"WebauthnProviderConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"AttestationPreference": Equal(configpb.ConveyancePreference_CONVEYANCE_PREFERENCE_NONE),
+							"AuthenticatorAttachment": Equal(
+								configpb.AuthenticatorAttachment_AUTHENTICATOR_ATTACHMENT_DEFAULT,
+							),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("CreateEmailNotification", func() {
+			configuration := &configpb.EmailServiceConfig{
+				DefaultFromAddress: &configpb.Email{Name: "indy", Address: "sos@example.com"},
+				Default:            true,
+				Provider: &configpb.EmailServiceConfig_Sendgrid{
+					Sendgrid: &configpb.SendGridProviderConfig{
+						ApiKey:      "12qe2e3r4t5y6u7i8o92t2t3t4t5y6u7i83h5h6",
+						SandboxMode: false,
+						IpPoolName: &wrapperspb.StringValue{
+							Value: "Like real IpPoolName Name",
+						},
+						Host: &wrapperspb.StringValue{
+							Value: "https://api.sendgrid.com",
+						},
+					},
+				},
+				InvitationMessage: &configpb.EmailDefinition{
+					Email: &configpb.EmailDefinition_Message{
+						Message: &configpb.EmailMessage{
+							From:    &configpb.Email{Name: "indy", Address: "sos@example.com"},
+							Subject: "invitation subject",
+						},
+					},
+				},
+			}
+
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithEmailNotificationConfig(configuration)
+
+			beResp := &configpb.CreateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwe",
+				CreatedBy:  "creator",
+				CreateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().CreateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Name":     Equal("like-real-config-node-name"),
+					"Location": Equal("gid:like-real-customer-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"EmailServiceConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"DefaultFromAddress": PointTo(MatchFields(IgnoreExtras, Fields{
+								"Name":    Equal("indy"),
+								"Address": Equal("sos@example.com"),
+							})),
+							"Default": Equal(true),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("CreateAuthFlow", func() {
+			configuration := &configpb.AuthFlowConfig{
+				SourceFormat: configpb.AuthFlowConfig_FORMAT_BARE_JSON,
+				Source:       []byte("wolf"),
+				Default:      false,
+			}
+
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithAuthFlowConfig(configuration)
+
+			beResp := &configpb.CreateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwe",
+				CreatedBy:  "creator",
+				CreateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().CreateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Name":     Equal("like-real-config-node-name"),
+					"Location": Equal("gid:like-real-customer-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"AuthFlowConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"SourceFormat": Equal(configpb.AuthFlowConfig_FORMAT_BARE_JSON),
+							"Default":      Equal(false),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("CreateAuthorizationPolicy", func() {
+			jsonInput := `{
+				"person1": 10,
+				"person2": 20,
+				"person3": 20
+			}`
+			configuration := &configpb.AuthorizationPolicyConfig{
+				Policy: jsonInput,
+				Status: configpb.AuthorizationPolicyConfig_STATUS_ACTIVE,
+				Tags:   []string{},
+			}
+
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithAuthorizationPolicyConfig(configuration)
+
+			beResp := &configpb.CreateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwe",
+				CreatedBy:  "creator",
+				CreateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().CreateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Name":     Equal("like-real-config-node-name"),
+					"Location": Equal("gid:like-real-customer-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"AuthorizationPolicyConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"Policy": Equal(jsonInput),
+							"Status": Equal(configpb.AuthorizationPolicyConfig_STATUS_ACTIVE),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("CreateKnowledgeGraphSchema", func() {
+			schemaInput := `
+				type Person implements DigitalTwin {
+					externalId: String!
+					digitalTwinId: String!
+					tenantId: String!
+					kind: DigitalTwinKind!
+					tags: [String!]!	
+				}
+			`
+			configuration := &configpb.KnowledgeGraphSchemaConfig{
+				Schema: schemaInput,
+			}
+
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithKnowledgeGraphSchemaConfig(configuration)
+
+			beResp := &configpb.CreateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwe",
+				CreatedBy:  "creator",
+				CreateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().CreateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Name":     Equal("like-real-config-node-name"),
+					"Location": Equal("gid:like-real-customer-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"KnowledgeGraphSchemaConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"Schema": Equal(schemaInput),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("CreateNonValid", func() {
+			configuration := &configpb.ReadIDProviderConfig{
+				SubmitterSecret:   "submitter-secret",
+				ManagerSecret:     "manager-secret-123456789012345678901234",
+				SubmitterPassword: "submitter-password",
+				HostAddress:       "<https://saas-preprod.readid.com>",
+				PropertyMap: map[string]*configpb.ReadIDProviderConfig_Property{
+					"Propertymap": {Expression: "property", Enabled: true},
+				},
+				UniquePropertyName: "uniquepropertyname",
+			}
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithReadidProviderConfig(configuration)
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("SubmitterSecret: value length must be at least 36 runes")))
+
+		})
+
+		It("CreateNonValidName", func() {
+
+			configNodeRequest, err := config.NewCreate("1234")
+			Expect(err).ToNot(Succeed())
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("invalid nil or not create request")))
+
+		})
+
+		It("CreateError", func() {
+			configuration := &configpb.ReadIDProviderConfig{
+				SubmitterSecret:   "submitter-secret-12345678901234567890",
+				ManagerSecret:     "manager-secret-123456789012345678901234",
+				SubmitterPassword: "submitter-password",
+				HostAddress:       "<https://saas-preprod.readid.com>",
+				PropertyMap: map[string]*configpb.ReadIDProviderConfig_Property{
+					"Propertymap": {Expression: "property", Enabled: true},
+				},
+				UniquePropertyName: "uniquepropertyname",
+			}
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithReadidProviderConfig(configuration)
+
+			beResp := &configpb.CreateConfigNodeResponse{}
+
+			mockClient.EXPECT().CreateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Name":     Equal("like-real-config-node-name"),
+					"Location": Equal("gid:like-real-customer-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"ReadidProviderConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"SubmitterSecret": Equal("submitter-secret-12345678901234567890"),
+							"ManagerSecret":   Equal("manager-secret-123456789012345678901234"),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.CreateConfigNode(ctx, configNodeRequest)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+
+		It("CreateString", func() {
+
+			configNodeRequest, err := config.NewCreate("like-real-config-node-name")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			resp := configNodeRequest.String()
+
+			Expect(resp).To(Not(BeNil()))
+			Expect(err).To(Succeed())
+			Expect(configNodeRequest).To(ContainSubstring("Create like-real-config-node-name configuration"))
+		})
+	})
+
+	Describe("ConfigNodeUpdate", func() {
+		It("Nil request", func() {
+			resp, err := configClient.UpdateConfigNode(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil or not update request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("UpdateReadId", func() {
+			configuration := &configpb.ReadIDProviderConfig{
+				SubmitterSecret:   "submitter-secret-12345678901234567890",
+				ManagerSecret:     "manager-secret-123456789012345678901234",
+				SubmitterPassword: "submitter-password",
+				HostAddress:       "<https://saas-preprod.readid.com>",
+				PropertyMap: map[string]*configpb.ReadIDProviderConfig_Property{
+					"Propertymap": {Expression: "property", Enabled: true},
+				},
+				UniquePropertyName: "uniquepropertyname",
+			}
+			configNodeRequest, err := config.NewUpdate("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.EmptyDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name Update")
+			configNodeRequest.EmptyDescription("Description")
+			configNodeRequest.WithDescription("Description")
+			configNodeRequest.WithPreCondition("qwert1234")
+			configNodeRequest.WithBookmarks([]string{"something-like-bookmark-which-is-long-enough"})
+			configNodeRequest.WithReadidProviderConfig(configuration)
+
+			beResp := &configpb.UpdateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwert",
+				UpdatedBy:  "creator",
+				UpdateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().UpdateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Id": Equal("gid:like-real-config-node-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"ReadidProviderConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"SubmitterSecret": Equal("submitter-secret-12345678901234567890"),
+							"ManagerSecret":   Equal("manager-secret-123456789012345678901234"),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.UpdateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("UpdateOAuth2Client", func() {
+			configuration := &configpb.OAuth2ClientConfig{
+				ProviderType:  configpb.ProviderType_PROVIDER_TYPE_GOOGLE_COM,
+				ClientId:      "client-id-123456789012345678901234",
+				ClientSecret:  "client-secret",
+				DefaultScopes: []string{"openid", "profile", "email"},
+				AllowedScopes: []string{"openid", "profile", "email"},
+			}
+
+			configNodeRequest, err := config.NewUpdate("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.EmptyDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name Update")
+			configNodeRequest.WithOAuth2ClientConfig(configuration)
+
+			beResp := &configpb.UpdateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwert",
+				UpdatedBy:  "creator",
+				UpdateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().UpdateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Id": Equal("gid:like-real-config-node-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Oauth2ClientConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"ClientId":     Equal("client-id-123456789012345678901234"),
+							"ClientSecret": Equal("client-secret"),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.UpdateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("UpdateWebAuthnProvider", func() {
+			configuration := &configpb.WebAuthnProviderConfig{
+				RelyingParties:          map[string]string{"http://localhost": "localhost"},
+				AttestationPreference:   configpb.ConveyancePreference_CONVEYANCE_PREFERENCE_NONE,
+				AuthenticatorAttachment: configpb.AuthenticatorAttachment_AUTHENTICATOR_ATTACHMENT_DEFAULT,
+				RequireResidentKey:      false,
+				UserVerification:        configpb.UserVerificationRequirement_USER_VERIFICATION_REQUIREMENT_PREFERRED,
+				RegistrationTimeout:     &durationpb.Duration{Seconds: 30},
+				AuthenticationTimeout:   &durationpb.Duration{Seconds: 60},
+			}
+
+			configNodeRequest, err := config.NewUpdate("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.EmptyDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name Update")
+			configNodeRequest.WithWebauthnProviderConfig(configuration)
+
+			beResp := &configpb.UpdateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwert",
+				UpdatedBy:  "creator",
+				UpdateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().UpdateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Id": Equal("gid:like-real-config-node-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"WebauthnProviderConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"AttestationPreference": Equal(configpb.ConveyancePreference_CONVEYANCE_PREFERENCE_NONE),
+							"AuthenticatorAttachment": Equal(
+								configpb.AuthenticatorAttachment_AUTHENTICATOR_ATTACHMENT_DEFAULT,
+							),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.UpdateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("UpdateEmailNotification", func() {
+			configuration := &configpb.EmailServiceConfig{
+				DefaultFromAddress: &configpb.Email{Name: "indy", Address: "sos@example.com"},
+				Default:            true,
+				Provider: &configpb.EmailServiceConfig_Sendgrid{
+					Sendgrid: &configpb.SendGridProviderConfig{
+						ApiKey:      "12qe2e3r4t5y6u7i8o92t2t3t4t5y6u7i83h5h6",
+						SandboxMode: false,
+						IpPoolName: &wrapperspb.StringValue{
+							Value: "Like real IpPoolName Name",
+						},
+						Host: &wrapperspb.StringValue{
+							Value: "https://api.sendgrid.com",
+						},
+					},
+				},
+				InvitationMessage: &configpb.EmailDefinition{
+					Email: &configpb.EmailDefinition_Message{
+						Message: &configpb.EmailMessage{
+							From:    &configpb.Email{Name: "indy", Address: "sos@example.com"},
+							Subject: "invitation subject",
+						},
+					},
+				},
+			}
+			configNodeRequest, err := config.NewUpdate("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.EmptyDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name Update")
+			configNodeRequest.WithEmailNotificationConfig(configuration)
+
+			beResp := &configpb.UpdateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwert",
+				UpdatedBy:  "creator",
+				UpdateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().UpdateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Id": Equal("gid:like-real-config-node-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"EmailServiceConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"DefaultFromAddress": PointTo(MatchFields(IgnoreExtras, Fields{
+								"Name":    Equal("indy"),
+								"Address": Equal("sos@example.com"),
+							})),
+							"Default": Equal(true),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.UpdateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("UpdateAuthFlow", func() {
+			configuration := &configpb.AuthFlowConfig{
+				SourceFormat: configpb.AuthFlowConfig_FORMAT_BARE_JSON,
+				Source:       []byte("wolf"),
+				Default:      false,
+			}
+
+			configNodeRequest, err := config.NewUpdate("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.EmptyDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name Update")
+			configNodeRequest.WithAuthFlowConfig(configuration)
+
+			beResp := &configpb.UpdateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwert",
+				UpdatedBy:  "creator",
+				UpdateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().UpdateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Id": Equal("gid:like-real-config-node-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"AuthFlowConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"SourceFormat": Equal(configpb.AuthFlowConfig_FORMAT_BARE_JSON),
+							"Default":      Equal(false),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.UpdateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("UpdateAuthorizationPolicy", func() {
+			jsonInput := `{
+				"person1": 10,
+				"person2": 20,
+				"person3": 20
+			}`
+			configuration := &configpb.AuthorizationPolicyConfig{
+				Policy: jsonInput,
+				Status: configpb.AuthorizationPolicyConfig_STATUS_ACTIVE,
+				Tags:   []string{},
+			}
+
+			configNodeRequest, err := config.NewUpdate("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.EmptyDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name Update")
+			configNodeRequest.WithAuthorizationPolicyConfig(configuration)
+
+			beResp := &configpb.UpdateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwert",
+				UpdatedBy:  "creator",
+				UpdateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().UpdateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Id": Equal("gid:like-real-config-node-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"AuthorizationPolicyConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"Policy": Equal(jsonInput),
+							"Status": Equal(configpb.AuthorizationPolicyConfig_STATUS_ACTIVE),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.UpdateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("UpdateKnowledgeGraphSchema", func() {
+			schemaInput := `
+				type Person implements DigitalTwin {
+					externalId: String!
+					digitalTwinId: String!
+					tenantId: String!
+					kind: DigitalTwinKind!
+					tags: [String!]!	
+				}
+			`
+			configuration := &configpb.KnowledgeGraphSchemaConfig{
+				Schema: schemaInput,
+			}
+
+			configNodeRequest, err := config.NewUpdate("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.EmptyDisplayName("Like real ConfigNode Name")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name Update")
+			configNodeRequest.WithKnowledgeGraphSchemaConfig(configuration)
+
+			beResp := &configpb.UpdateConfigNodeResponse{
+				Id:         "gid:like-real-config-node-id",
+				Etag:       "123qwert",
+				UpdatedBy:  "creator",
+				UpdateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().UpdateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Id": Equal("gid:like-real-config-node-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"KnowledgeGraphSchemaConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"Schema": Equal(schemaInput),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.UpdateConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("UpdateNonValid", func() {
+			configNodeRequest, err := config.NewUpdate("12345")
+			Ω(err).To(Succeed())
+			resp, err := configClient.UpdateConfigNode(ctx, configNodeRequest)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+		})
+
+		It("UpdateError", func() {
+			configuration := &configpb.ReadIDProviderConfig{
+				SubmitterSecret:   "submitter-secret-12345678901234567890",
+				ManagerSecret:     "manager-secret-123456789012345678901234",
+				SubmitterPassword: "submitter-password",
+				HostAddress:       "<https://saas-preprod.readid.com>",
+				PropertyMap: map[string]*configpb.ReadIDProviderConfig_Property{
+					"Propertymap": {Expression: "property", Enabled: true},
+				},
+				UniquePropertyName: "uniquepropertyname",
+			}
+			configNodeRequest, err := config.NewUpdate("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name Update")
+			configNodeRequest.WithReadidProviderConfig(configuration)
+
+			beResp := &configpb.UpdateConfigNodeResponse{}
+
+			mockClient.EXPECT().UpdateConfigNode(
+				gomock.Any(),
+				test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Id": Equal("gid:like-real-config-node-id"),
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"ReadidProviderConfig": PointTo(MatchFields(IgnoreExtras, Fields{
+							"SubmitterSecret": Equal("submitter-secret-12345678901234567890"),
+							"ManagerSecret":   Equal("manager-secret-123456789012345678901234"),
+						})),
+					})),
+				}))),
+				gomock.Any(),
+			).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.UpdateConfigNode(ctx, configNodeRequest)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+
+		It("UpdateString", func() {
+
+			configNodeRequest, err := config.NewUpdate("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.ForLocation("gid:like-real-customer-id")
+			configNodeRequest.WithDisplayName("Like real ConfigNode Name")
+			resp := configNodeRequest.String()
+
+			Expect(resp).To(Not(BeNil()))
+			Expect(err).To(Succeed())
+			Expect(configNodeRequest).To(ContainSubstring("Update gid:like-real-config-node-id configuration"))
+		})
+
+	})
+
+	Describe("ConfigNodeDelete", func() {
+		It("Nil request", func() {
+			resp, err := configClient.DeleteConfigNode(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil or not delete request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("Wrong id should return a validation error in the response", func() {
+			configNodeRequest, err := config.NewDelete("gid:like")
+			Ω(err).To(Succeed())
+			resp, err := configClient.DeleteConfigNode(ctx, configNodeRequest)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+
+		})
+
+		It("Delete", func() {
+			configNodeRequest, err := config.NewDelete("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			configNodeRequest.WithPreCondition("qwert1234")
+			configNodeRequest.WithBookmarks([]string{"something-like-bookmark-which-is-long-enough"})
+			beResp := &configpb.DeleteConfigNodeResponse{
+				Bookmark: "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().
+				DeleteConfigNode(
+					gomock.Any(),
+					test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Id": Equal("gid:like-real-config-node-id"),
+					}))),
+					gomock.Any(),
+				).Return(beResp, nil)
+
+			resp, err := configClient.DeleteConfigNode(ctx, configNodeRequest)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("DeleteError", func() {
+			configNodeRequest, err := config.NewDelete("gid:like-real-config-node-id")
+			Ω(err).To(Succeed())
+			beResp := &configpb.DeleteConfigNodeResponse{}
+
+			mockClient.EXPECT().
+				DeleteConfigNode(
+					gomock.Any(),
+					test.WrapMatcher(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Id": Equal("gid:like-real-config-node-id"),
+					}))),
+					gomock.Any(),
+				).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.DeleteConfigNode(ctx, configNodeRequest)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+
+		It("DeleteString", func() {
+
+			configNodeRequest, err := config.NewDelete("gid:like-real-config-node-id")
+			resp := configNodeRequest.String()
+
+			Expect(resp).To(Not(BeNil()))
+			Expect(err).To(Succeed())
+			Expect(configNodeRequest).To(ContainSubstring("Delete gid:like-real-config-node-id configuration"))
+		})
+	})
+
+})

--- a/config/config_request.go
+++ b/config/config_request.go
@@ -248,6 +248,46 @@ func (x *NodeRequest) WithKnowledgeGraphSchemaConfig(v *configpb.KnowledgeGraphS
 	return x
 }
 
+func (x *NodeRequest) WithWebauthnProviderConfig(v *configpb.WebAuthnProviderConfig) *NodeRequest {
+	switch {
+	case x.create != nil:
+		x.create.Config = nil
+		if v != nil {
+			x.create.Config = &configpb.CreateConfigNodeRequest_WebauthnProviderConfig{
+				WebauthnProviderConfig: v,
+			}
+		}
+	case x.update != nil:
+		x.update.Config = nil
+		if v != nil {
+			x.update.Config = &configpb.UpdateConfigNodeRequest_WebauthnProviderConfig{
+				WebauthnProviderConfig: v,
+			}
+		}
+	}
+	return x
+}
+
+func (x *NodeRequest) WithReadidProviderConfig(v *configpb.ReadIDProviderConfig) *NodeRequest {
+	switch {
+	case x.create != nil:
+		x.create.Config = nil
+		if v != nil {
+			x.create.Config = &configpb.CreateConfigNodeRequest_ReadidProviderConfig{
+				ReadidProviderConfig: v,
+			}
+		}
+	case x.update != nil:
+		x.update.Config = nil
+		if v != nil {
+			x.update.Config = &configpb.UpdateConfigNodeRequest_ReadidProviderConfig{
+				ReadidProviderConfig: v,
+			}
+		}
+	}
+	return x
+}
+
 func (x *NodeRequest) optionalString(v string) *wrapperspb.StringValue {
 	return wrapperspb.String(strings.TrimSpace(v))
 }

--- a/config/oauth2_application_test.go
+++ b/config/oauth2_application_test.go
@@ -1,0 +1,448 @@
+// Copyright (c) 2023 IndyKite
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/indykite/indykite-sdk-go/config"
+	sdkerrors "github.com/indykite/indykite-sdk-go/errors"
+	configpb "github.com/indykite/indykite-sdk-go/gen/indykite/config/v1beta1"
+	"github.com/indykite/indykite-sdk-go/test"
+	configmock "github.com/indykite/indykite-sdk-go/test/config/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OAuth2Application", func() {
+	var (
+		ctx          context.Context
+		mockCtrl     *gomock.Controller
+		mockClient   *configmock.MockConfigManagementAPIClient
+		configClient *config.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = configmock.NewMockConfigManagementAPIClient(mockCtrl)
+
+		var err error
+		configClient, err = config.NewTestClient(ctx, mockClient)
+		Ω(err).To(Succeed())
+	})
+
+	Describe("OAuth2Application", func() {
+		It("Nil request", func() {
+			resp, err := configClient.ReadOAuth2Application(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("Wrong id should return a validation error in the response", func() {
+			req := &configpb.ReadOAuth2ApplicationRequest{Id: "gid:like"}
+			resp, err := configClient.ReadOAuth2Application(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+
+		})
+
+		It("ReadSuccess", func() {
+			req := &configpb.ReadOAuth2ApplicationRequest{Id: "gid:like-real-oauth2-application-id"}
+			beResp := &configpb.ReadOAuth2ApplicationResponse{
+				Oauth2Application: &configpb.OAuth2Application{
+					Id:               "gid:like-real-oauth2-application-id",
+					Name:             "like-real-oauth2-application-name",
+					DisplayName:      "Like Real Oauth2-Application Name",
+					CreatedBy:        "creator",
+					CreateTime:       timestamppb.Now(),
+					CustomerId:       "gid:like-real-customer-id",
+					AppSpaceId:       "gid:like-real-app-space-id",
+					Etag:             "123qwe",
+					Oauth2ProviderId: "gid:like-real-oauth2-provider-id",
+					Config: &configpb.OAuth2ApplicationConfig{
+						ClientId:    "00000000-90af-4ef9-9928-aaaaaaaaaaaa",
+						DisplayName: "Some cool public display name",
+						SubjectType: configpb.ClientSubjectType_CLIENT_SUBJECT_TYPE_PUBLIC,
+						GrantTypes: []configpb.GrantType{
+							configpb.GrantType_GRANT_TYPE_AUTHORIZATION_CODE,
+						},
+						ResponseTypes: []configpb.ResponseType{configpb.ResponseType_RESPONSE_TYPE_CODE},
+						Scopes:        []string{"openid", "profile", "email"},
+						Audiences:     []string{"7d2e906e-541a-49da-b5b2-a28840ff8721"},
+						TokenEndpointAuthMethod: configpb.
+							TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST,
+						TokenEndpointAuthSigningAlg: "ES256",
+						RedirectUris:                []string{"http://localhost:3000/redirect"},
+						Owner:                       "Owner",
+						PolicyUri:                   "http://localhost:3000/policy",
+						TermsOfServiceUri:           "http://localhost:3000/policy",
+						ClientUri:                   "http://localhost:3000/client",
+						LogoUri:                     "http://localhost:3000/logo",
+						UserSupportEmailAddress:     "test@example.com",
+					},
+				},
+			}
+			mockClient.EXPECT().
+				ReadOAuth2Application(
+					gomock.Any(),
+					test.WrapMatcher(test.EqualProto(req)),
+					gomock.Any(),
+				).Return(beResp, nil)
+
+			resp, err := configClient.ReadOAuth2Application(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("ReadError", func() {
+			req := &configpb.ReadOAuth2ApplicationRequest{Id: "gid:like-real-oauth2-application-id"}
+			beResp := &configpb.ReadOAuth2ApplicationResponse{
+				Oauth2Application: &configpb.OAuth2Application{
+					Id:               "gid:like-real-oauth2-application-id",
+					Name:             "like-real-oauth2-application-name",
+					Etag:             "123qwe",
+					Oauth2ProviderId: "gid:like-real-oauth2-provider-id",
+					Config:           &configpb.OAuth2ApplicationConfig{},
+				},
+			}
+			mockClient.EXPECT().
+				ReadOAuth2Application(
+					gomock.Any(),
+					test.WrapMatcher(test.EqualProto(req)),
+					gomock.Any(),
+				).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.ReadOAuth2Application(ctx, req)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+	})
+
+	Describe("OAuth2ApplicationCreate", func() {
+		It("Nil request", func() {
+			resp, err := configClient.CreateOAuth2Application(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("Create", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Application Name"}
+			req := &configpb.CreateOAuth2ApplicationRequest{
+				Oauth2ProviderId: "gid:like-real-oauth2-provider-id",
+				Name:             "like-real-oauth2-application-name",
+				DisplayName:      displayNamePb,
+				Config: &configpb.OAuth2ApplicationConfig{
+					ClientId:    "00000000-90af-4ef9-9928-aaaaaaaaaaaa",
+					DisplayName: "Some cool public display name",
+					SubjectType: configpb.ClientSubjectType_CLIENT_SUBJECT_TYPE_PUBLIC,
+					GrantTypes:  []configpb.GrantType{configpb.GrantType_GRANT_TYPE_AUTHORIZATION_CODE},
+					ResponseTypes: []configpb.ResponseType{configpb.
+						ResponseType_RESPONSE_TYPE_CODE},
+					Scopes:    []string{"openid", "profile", "email"},
+					Audiences: []string{"7d2e906e-541a-49da-b5b2-a28840ff8721"},
+					TokenEndpointAuthMethod: configpb.
+						TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST,
+					TokenEndpointAuthSigningAlg: "ES256",
+					RedirectUris:                []string{"http://localhost:3000/redirect"},
+					Owner:                       "Owner",
+					PolicyUri:                   "http://localhost:3000/policy",
+					TermsOfServiceUri:           "http://localhost:3000/policy",
+					ClientUri:                   "http://localhost:3000/client",
+					LogoUri:                     "http://localhost:3000/logo",
+					UserSupportEmailAddress:     "test@example.com",
+				},
+			}
+			beResp := &configpb.CreateOAuth2ApplicationResponse{
+				Id:         "gid:like-real-oauth2-application-id",
+				Etag:       "123qwe",
+				CreatedBy:  "creator",
+				CreateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().CreateOAuth2Application(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.CreateOAuth2Application(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("CreateNonValid", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Application Name"}
+			req := &configpb.CreateOAuth2ApplicationRequest{
+				Oauth2ProviderId: "error-id",
+				Name:             "like-real-oauth2-application-name",
+				DisplayName:      displayNamePb,
+				Config:           &configpb.OAuth2ApplicationConfig{},
+			}
+
+			resp, err := configClient.CreateOAuth2Application(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+		})
+
+		It("CreateError", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Application Name"}
+			req := &configpb.CreateOAuth2ApplicationRequest{
+				Oauth2ProviderId: "gid:like-real-oauth2-provider-id",
+				Name:             "like-real-oauth2-application-name",
+				DisplayName:      displayNamePb,
+				Config: &configpb.OAuth2ApplicationConfig{
+					ClientId:    "00000000-90af-4ef9-9928-aaaaaaaaaaaa",
+					DisplayName: "Some cool public display name",
+					SubjectType: configpb.ClientSubjectType_CLIENT_SUBJECT_TYPE_PUBLIC,
+					GrantTypes: []configpb.GrantType{configpb.
+						GrantType_GRANT_TYPE_AUTHORIZATION_CODE},
+					ResponseTypes: []configpb.ResponseType{configpb.ResponseType_RESPONSE_TYPE_CODE},
+					Scopes:        []string{"openid", "profile", "email"},
+					Audiences:     []string{"7d2e906e-541a-49da-b5b2-a28840ff8721"},
+					TokenEndpointAuthMethod: configpb.
+						TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST,
+					TokenEndpointAuthSigningAlg: "ES256",
+					RedirectUris:                []string{"http://localhost:3000/redirect"},
+					Owner:                       "Owner",
+					PolicyUri:                   "http://localhost:3000/policy",
+					TermsOfServiceUri:           "http://localhost:3000/policy",
+					ClientUri:                   "http://localhost:3000/client",
+					LogoUri:                     "http://localhost:3000/logo",
+					UserSupportEmailAddress:     "test@example.com",
+				},
+			}
+			beResp := &configpb.CreateOAuth2ApplicationResponse{}
+			mockClient.EXPECT().CreateOAuth2Application(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.CreateOAuth2Application(ctx, req)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+
+	})
+
+	Describe("OAuth2ApplicationUpdate", func() {
+		It("Nil request", func() {
+			resp, err := configClient.UpdateOAuth2Application(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("Update", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Application Name"}
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.UpdateOAuth2ApplicationRequest{
+				Id:          "gid:like-real-oauth2-application-id",
+				Etag:        etagPb,
+				DisplayName: displayNamePb,
+				Config: &configpb.OAuth2ApplicationConfig{
+					ClientId:    "00000000-90af-4ef9-9928-aaaaaaaaaaaa",
+					DisplayName: "Some cool public display name",
+					SubjectType: configpb.ClientSubjectType_CLIENT_SUBJECT_TYPE_PUBLIC,
+					GrantTypes: []configpb.GrantType{configpb.
+						GrantType_GRANT_TYPE_AUTHORIZATION_CODE},
+					ResponseTypes: []configpb.ResponseType{configpb.ResponseType_RESPONSE_TYPE_CODE},
+					Scopes:        []string{"openid", "profile", "email"},
+					Audiences:     []string{"7d2e906e-541a-49da-b5b2-a28840ff8721"},
+					TokenEndpointAuthMethod: configpb.
+						TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST,
+					TokenEndpointAuthSigningAlg: "ES256",
+					RedirectUris:                []string{"http://localhost:3000/redirect"},
+					Owner:                       "Owner",
+					PolicyUri:                   "http://localhost:3000/policy",
+					TermsOfServiceUri:           "http://localhost:3000/policy",
+					ClientUri:                   "http://localhost:3000/client",
+					LogoUri:                     "http://localhost:3000/logo",
+					UserSupportEmailAddress:     "test@example.com",
+				},
+			}
+			beResp := &configpb.UpdateOAuth2ApplicationResponse{
+				Id:         "gid:like-real-oauth2-application-id",
+				Etag:       "123qwert",
+				UpdatedBy:  "creator",
+				UpdateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().UpdateOAuth2Application(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.UpdateOAuth2Application(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("UpdateNonValid", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Application Name"}
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.UpdateOAuth2ApplicationRequest{
+				Id:          "wrong-id",
+				Etag:        etagPb,
+				DisplayName: displayNamePb,
+				Config:      &configpb.OAuth2ApplicationConfig{},
+			}
+			resp, err := configClient.UpdateOAuth2Application(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+		})
+
+		It("UpdateError", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Application Name"}
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.UpdateOAuth2ApplicationRequest{
+				Id:          "gid:like-real-oauth2-application-id",
+				Etag:        etagPb,
+				DisplayName: displayNamePb,
+				Config: &configpb.OAuth2ApplicationConfig{
+					ClientId:    "00000000-90af-4ef9-9928-aaaaaaaaaaaa",
+					DisplayName: "Some cool public display name",
+					SubjectType: configpb.ClientSubjectType_CLIENT_SUBJECT_TYPE_PUBLIC,
+					GrantTypes: []configpb.
+						GrantType{configpb.GrantType_GRANT_TYPE_AUTHORIZATION_CODE},
+					ResponseTypes: []configpb.ResponseType{configpb.ResponseType_RESPONSE_TYPE_CODE},
+					Scopes:        []string{"openid", "profile", "email"},
+					Audiences:     []string{"7d2e906e-541a-49da-b5b2-a28840ff8721"},
+					TokenEndpointAuthMethod: configpb.
+						TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST,
+					TokenEndpointAuthSigningAlg: "ES256",
+					RedirectUris:                []string{"http://localhost:3000/redirect"},
+					Owner:                       "Owner",
+					PolicyUri:                   "http://localhost:3000/policy",
+					TermsOfServiceUri:           "http://localhost:3000/policy",
+					ClientUri:                   "http://localhost:3000/client",
+					LogoUri:                     "http://localhost:3000/logo",
+					UserSupportEmailAddress:     "test@example.com",
+				},
+			}
+			beResp := &configpb.UpdateOAuth2ApplicationResponse{}
+
+			mockClient.EXPECT().UpdateOAuth2Application(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.UpdateOAuth2Application(ctx, req)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+
+	})
+
+	Describe("OAuth2ApplicationDelete", func() {
+		It("Nil request", func() {
+			resp, err := configClient.DeleteOAuth2Application(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("should return an length error in the response", func() {
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.DeleteOAuth2ApplicationRequest{
+				Id:   "like-real",
+				Etag: etagPb,
+			}
+			resp, err := configClient.DeleteOAuth2Application(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+
+		})
+
+		It("Delete", func() {
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.DeleteOAuth2ApplicationRequest{
+				Id:   "gid:like-real-oauth2-application-id",
+				Etag: etagPb,
+			}
+			beResp := &configpb.DeleteOAuth2ApplicationResponse{
+				Bookmark: "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().DeleteOAuth2Application(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.DeleteOAuth2Application(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("DeleteError", func() {
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.DeleteOAuth2ApplicationRequest{
+				Id:   "gid:like-real-oauth2-application-id",
+				Etag: etagPb,
+			}
+			beResp := &configpb.DeleteOAuth2ApplicationResponse{}
+
+			mockClient.EXPECT().DeleteOAuth2Application(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.DeleteOAuth2Application(ctx, req)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+	})
+})

--- a/config/oauth2_provider_test.go
+++ b/config/oauth2_provider_test.go
@@ -1,0 +1,410 @@
+// Copyright (c) 2023 IndyKite
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/indykite/indykite-sdk-go/config"
+	sdkerrors "github.com/indykite/indykite-sdk-go/errors"
+	configpb "github.com/indykite/indykite-sdk-go/gen/indykite/config/v1beta1"
+	"github.com/indykite/indykite-sdk-go/test"
+	configmock "github.com/indykite/indykite-sdk-go/test/config/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OAuth2Provider", func() {
+	var (
+		ctx          context.Context
+		mockCtrl     *gomock.Controller
+		mockClient   *configmock.MockConfigManagementAPIClient
+		configClient *config.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = configmock.NewMockConfigManagementAPIClient(mockCtrl)
+
+		var err error
+		configClient, err = config.NewTestClient(ctx, mockClient)
+		Ω(err).To(Succeed())
+	})
+
+	Describe("OAuth2Provider", func() {
+		It("Nil request", func() {
+			resp, err := configClient.ReadOAuth2Provider(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("Wrong id should return a validation error in the response", func() {
+			req := &configpb.ReadOAuth2ProviderRequest{Id: "gid:like"}
+			resp, err := configClient.ReadOAuth2Provider(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+
+		})
+
+		It("ReadSuccess", func() {
+			req := &configpb.ReadOAuth2ProviderRequest{Id: "gid:like-real-oauth2-provider-id"}
+			beResp := &configpb.ReadOAuth2ProviderResponse{
+				Oauth2Provider: &configpb.OAuth2Provider{
+					Id:          "gid:like-real-oauth2-provider-id",
+					Name:        "like-real-oauth2-provider-name",
+					DisplayName: "Like Real OAuth2-Provider Name",
+					CreatedBy:   "creator",
+					CreateTime:  timestamppb.Now(),
+					CustomerId:  "gid:like-real-customer-id",
+					AppSpaceId:  "gid:like-real-app-space-id",
+					Etag:        "123qwe",
+					Config: &configpb.OAuth2ProviderConfig{
+						GrantTypes: []configpb.GrantType{configpb.
+							GrantType_GRANT_TYPE_AUTHORIZATION_CODE},
+						ResponseTypes: []configpb.ResponseType{configpb.
+							ResponseType_RESPONSE_TYPE_CODE, configpb.ResponseType_RESPONSE_TYPE_TOKEN},
+						Scopes: []string{"openid", "profile", "email"},
+						TokenEndpointAuthMethod: []configpb.TokenEndpointAuthMethod{configpb.
+							TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST},
+						TokenEndpointAuthSigningAlg: []string{"ES256", "ES384", "ES512"},
+						RequestUris:                 make([]string, 0),
+						RequestObjectSigningAlg:     "ES256",
+						FrontChannelLoginUri:        map[string]string{"default": "http://localhost:3000/login/oauth2"},
+						FrontChannelConsentUri:      map[string]string{"default": "http://localhost:3000/consent"},
+					},
+				},
+			}
+			mockClient.EXPECT().
+				ReadOAuth2Provider(
+					gomock.Any(),
+					test.WrapMatcher(test.EqualProto(req)),
+					gomock.Any(),
+				).Return(beResp, nil)
+
+			resp, err := configClient.ReadOAuth2Provider(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("ReadError", func() {
+			req := &configpb.ReadOAuth2ProviderRequest{Id: "gid:like-real-oauth2-provider-id"}
+			beResp := &configpb.ReadOAuth2ProviderResponse{
+				Oauth2Provider: &configpb.OAuth2Provider{
+					Id:     "gid:like-real-oauth2-provider-id",
+					Name:   "like-real-oauth2-provider-name",
+					Etag:   "123qwe",
+					Config: &configpb.OAuth2ProviderConfig{},
+				},
+			}
+			mockClient.EXPECT().
+				ReadOAuth2Provider(
+					gomock.Any(),
+					test.WrapMatcher(test.EqualProto(req)),
+					gomock.Any(),
+				).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.ReadOAuth2Provider(ctx, req)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+	})
+
+	Describe("OAuth2ProviderCreate", func() {
+		It("Nil request", func() {
+			resp, err := configClient.CreateOAuth2Provider(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("Create", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Provider Name"}
+			req := &configpb.CreateOAuth2ProviderRequest{
+				AppSpaceId:  "gid:like-real-app-space-id",
+				Name:        "like-real-oauth2-provider-name",
+				DisplayName: displayNamePb,
+				Config: &configpb.OAuth2ProviderConfig{
+					GrantTypes: []configpb.GrantType{configpb.GrantType_GRANT_TYPE_AUTHORIZATION_CODE},
+					ResponseTypes: []configpb.ResponseType{configpb.
+						ResponseType_RESPONSE_TYPE_CODE, configpb.ResponseType_RESPONSE_TYPE_TOKEN},
+					Scopes: []string{"openid", "profile", "email"},
+					TokenEndpointAuthMethod: []configpb.TokenEndpointAuthMethod{configpb.
+						TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST},
+					TokenEndpointAuthSigningAlg: []string{"ES256", "ES384", "ES512"},
+					RequestUris:                 make([]string, 0),
+					RequestObjectSigningAlg:     "ES256",
+					FrontChannelLoginUri:        map[string]string{"default": "http://localhost:3000/login/oauth2"},
+					FrontChannelConsentUri:      map[string]string{"default": "http://localhost:3000/consent"},
+				},
+			}
+			beResp := &configpb.CreateOAuth2ProviderResponse{
+				Id:         "gid:like-real-oauth2-provider-id",
+				Etag:       "123qwe",
+				CreatedBy:  "creator",
+				CreateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().CreateOAuth2Provider(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.CreateOAuth2Provider(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("CreateNonValid", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Provider Name"}
+			req := &configpb.CreateOAuth2ProviderRequest{
+				AppSpaceId:  "error-app-space-id",
+				Name:        "like-real-oauth2-provider-name",
+				DisplayName: displayNamePb,
+			}
+
+			resp, err := configClient.CreateOAuth2Provider(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+		})
+
+		It("CreateError", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Provider Name"}
+			req := &configpb.CreateOAuth2ProviderRequest{
+				AppSpaceId:  "gid:like-real-app-space-id",
+				Name:        "like-real-oauth2-provider-name",
+				DisplayName: displayNamePb,
+				Config: &configpb.OAuth2ProviderConfig{
+					GrantTypes: []configpb.GrantType{configpb.GrantType_GRANT_TYPE_AUTHORIZATION_CODE},
+					ResponseTypes: []configpb.ResponseType{configpb.
+						ResponseType_RESPONSE_TYPE_CODE, configpb.ResponseType_RESPONSE_TYPE_TOKEN},
+					Scopes: []string{"openid", "profile", "email"},
+					TokenEndpointAuthMethod: []configpb.TokenEndpointAuthMethod{configpb.
+						TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST},
+					TokenEndpointAuthSigningAlg: []string{"ES256", "ES384", "ES512"},
+					RequestUris:                 make([]string, 0),
+					RequestObjectSigningAlg:     "ES256",
+					FrontChannelLoginUri:        map[string]string{"default": "http://localhost:3000/login/oauth2"},
+					FrontChannelConsentUri:      map[string]string{"default": "http://localhost:3000/consent"},
+				},
+			}
+			beResp := &configpb.CreateOAuth2ProviderResponse{}
+			mockClient.EXPECT().CreateOAuth2Provider(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.CreateOAuth2Provider(ctx, req)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+
+	})
+
+	Describe("OAuth2ProviderUpdate", func() {
+		It("Nil request", func() {
+			resp, err := configClient.UpdateOAuth2Provider(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("Update", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Provider Name"}
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.UpdateOAuth2ProviderRequest{
+				Id:          "gid:like-real-oauth2-provider-id",
+				Etag:        etagPb,
+				DisplayName: displayNamePb,
+				Config: &configpb.OAuth2ProviderConfig{
+					GrantTypes: []configpb.GrantType{configpb.GrantType_GRANT_TYPE_AUTHORIZATION_CODE},
+					ResponseTypes: []configpb.ResponseType{configpb.
+						ResponseType_RESPONSE_TYPE_CODE, configpb.ResponseType_RESPONSE_TYPE_TOKEN},
+					Scopes: []string{"openid", "profile", "email"},
+					TokenEndpointAuthMethod: []configpb.TokenEndpointAuthMethod{configpb.
+						TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST},
+					TokenEndpointAuthSigningAlg: []string{"ES256", "ES384", "ES512"},
+					RequestUris:                 make([]string, 0),
+					RequestObjectSigningAlg:     "ES256",
+					FrontChannelLoginUri:        map[string]string{"default": "http://localhost:3000/login/oauth2"},
+					FrontChannelConsentUri:      map[string]string{"default": "http://localhost:3000/consent"},
+				},
+			}
+			beResp := &configpb.UpdateOAuth2ProviderResponse{
+				Id:         "gid:like-real-oauth2-provider-id",
+				Etag:       "123qwert",
+				UpdatedBy:  "creator",
+				UpdateTime: timestamppb.Now(),
+				Bookmark:   "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().UpdateOAuth2Provider(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.UpdateOAuth2Provider(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("UpdateNonValid", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Provider Name"}
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.UpdateOAuth2ProviderRequest{
+				Id:          "wrong-id",
+				Etag:        etagPb,
+				DisplayName: displayNamePb,
+				Config:      &configpb.OAuth2ProviderConfig{},
+			}
+			resp, err := configClient.UpdateOAuth2Provider(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+		})
+
+		It("UpdateError", func() {
+			displayNamePb := &wrapperspb.StringValue{Value: "Like real OAuth2Provider Name"}
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.UpdateOAuth2ProviderRequest{
+				Id:          "gid:like-real-oauth2-provider-id",
+				Etag:        etagPb,
+				DisplayName: displayNamePb,
+				Config: &configpb.OAuth2ProviderConfig{
+					GrantTypes: []configpb.GrantType{configpb.GrantType_GRANT_TYPE_AUTHORIZATION_CODE},
+					ResponseTypes: []configpb.ResponseType{configpb.
+						ResponseType_RESPONSE_TYPE_CODE, configpb.ResponseType_RESPONSE_TYPE_TOKEN},
+					Scopes: []string{"openid", "profile", "email"},
+					TokenEndpointAuthMethod: []configpb.TokenEndpointAuthMethod{configpb.
+						TokenEndpointAuthMethod_TOKEN_ENDPOINT_AUTH_METHOD_CLIENT_SECRET_POST},
+					TokenEndpointAuthSigningAlg: []string{"ES256", "ES384", "ES512"},
+					RequestUris:                 make([]string, 0),
+					RequestObjectSigningAlg:     "ES256",
+					FrontChannelLoginUri:        map[string]string{"default": "http://localhost:3000/login/oauth2"},
+					FrontChannelConsentUri:      map[string]string{"default": "http://localhost:3000/consent"},
+				},
+			}
+			beResp := &configpb.UpdateOAuth2ProviderResponse{}
+
+			mockClient.EXPECT().UpdateOAuth2Provider(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.UpdateOAuth2Provider(ctx, req)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+
+	})
+
+	Describe("OAuth2ProviderDelete", func() {
+		It("Nil request", func() {
+			resp, err := configClient.DeleteOAuth2Provider(ctx, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(resp).To(BeNil())
+
+			var clientErr *sdkerrors.ClientError
+			Expect(errors.As(err, &clientErr)).To(BeTrue(), "is client error")
+			Expect(clientErr.Unwrap()).To(Succeed())
+			Expect(clientErr.Message()).To(Equal("invalid nil request"))
+			Expect(clientErr.Code()).To(Equal(codes.InvalidArgument))
+
+		})
+
+		It("should return an length error in the response", func() {
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.DeleteOAuth2ProviderRequest{
+				Id:   "like-real",
+				Etag: etagPb,
+			}
+			resp, err := configClient.DeleteOAuth2Provider(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("Id: value length must be between 22")))
+
+		})
+
+		It("Delete", func() {
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.DeleteOAuth2ProviderRequest{
+				Id:   "gid:like-real-oauth2-provider-id",
+				Etag: etagPb,
+			}
+			beResp := &configpb.DeleteOAuth2ProviderResponse{
+				Bookmark: "something-like-bookmark-which-is-long-enough",
+			}
+
+			mockClient.EXPECT().DeleteOAuth2Provider(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, nil)
+
+			resp, err := configClient.DeleteOAuth2Provider(ctx, req)
+			Expect(err).To(Succeed())
+			Expect(resp).To(test.EqualProto(beResp))
+		})
+
+		It("DeleteError", func() {
+			etagPb := &wrapperspb.StringValue{Value: "123qwert"}
+			req := &configpb.DeleteOAuth2ProviderRequest{
+				Id:   "gid:like-real-oauth2-provider-id",
+				Etag: etagPb,
+			}
+			beResp := &configpb.DeleteOAuth2ProviderResponse{}
+
+			mockClient.EXPECT().DeleteOAuth2Provider(
+				gomock.Any(),
+				test.WrapMatcher(test.EqualProto(req)),
+				gomock.Any(),
+			).Return(beResp, status.Error(codes.InvalidArgument, "status error"))
+
+			resp, err := configClient.DeleteOAuth2Provider(ctx, req)
+			Expect(err).ToNot(Succeed())
+			Expect(resp).To(BeNil())
+		})
+	})
+})

--- a/config/utilities.go
+++ b/config/utilities.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/pborman/uuid"
-
 	"github.com/indykite/indykite-sdk-go/errors"
 )
 
@@ -28,14 +26,6 @@ const (
 )
 
 var nameCheck = regexp.MustCompile(fmt.Sprintf(rfc1035NameTemplate, 0, 252))
-
-// IsUUIDv4 checks if id is valid RFC4122 varian UUID.
-func IsUUIDv4(key string, id []byte) error {
-	if uuid.UUID(id).Variant() != uuid.RFC4122 {
-		return errors.NewInvalidArgumentError("expected UUID RFC4122 variant")
-	}
-	return nil
-}
 
 // IsValidName checks if name is valid RFC1035 string.
 //
@@ -46,14 +36,4 @@ func IsValidName(name string) error {
 		return errors.NewInvalidArgumentError("name value must be valid RFC1035 string with length 2-254")
 	}
 	return nil
-}
-
-// ContainsLabel check if string array contains given node label.
-func ContainsLabel(arr []string, searchFor string) bool {
-	for _, v := range arr {
-		if searchFor == v {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Closing ENG-1561
- add unit tests in config
- add missing config nodes webauthn and readid
- remove outdated methods
